### PR TITLE
Latest tag

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,8 +9,9 @@ dependencies:
     - sudo apt-get install git
     - gem install tugboat
     - echo -e "${TUGBOAT_TOKEN}\n~/.ssh/id_rsa\nroot\n22\ntor1\nubuntu-14-04-x64\n512mb\n${TUGBOAT_KEYS}\nfalse\nfalse\nfalse" | tugboat authorize
-    - (cd /tmp ; git clone git@github.com:cloud-elements/hykes-blueprint.git)
-    - (cd /tmp/hykes-blueprint ; make && make install)
+    - (cd /tmp; git clone git@github.com:cloud-elements/hykes-blueprint.git)
+    - (cd /tmp/hykes-blueprint; git checkout $(git describe --tags $(git rev-list --tags --max-count=1)))
+    - (cd /tmp/hykes-blueprint; make && make install)
     - sudo ln -s /tmp/hykes-blueprint/build/bin/hykes-blueprint /usr/local/bin/hykes-blueprint
 
 test:

--- a/test/integration/suite.bash
+++ b/test/integration/suite.bash
@@ -2,6 +2,7 @@
 
 function clone-repo() {
   git clone git@github.com:cloud-elements/hykes-spec.git build/tmp/hykes-spec
+  (cd build/tmp/hykes-spec && git checkout $(git describe --tags $(git rev-list --tags --max-count=1)))
 }
 
 function exists-repo() {

--- a/test/integration/suite.bash
+++ b/test/integration/suite.bash
@@ -2,7 +2,8 @@
 
 function clone-repo() {
   git clone git@github.com:cloud-elements/hykes-spec.git build/tmp/hykes-spec
-  (cd build/tmp/hykes-spec && git checkout $(git describe --tags $(git rev-list --tags --max-count=1)))
+  (cd build/tmp/hykes-spec && \
+    git checkout $(git describe --tags $(git rev-list --tags --max-count=1)))
 }
 
 function exists-repo() {


### PR DESCRIPTION
## Summary

An issue arises, due to the continuous release approach of both blueprint and spec, in which potentially breaking changes could be picked up from master. Instead, we want to use the latest tag for each of the dependent projects instead.
## Closes
- Closes #55 
